### PR TITLE
Allow images with broken headers to load.

### DIFF
--- a/run.py
+++ b/run.py
@@ -5,8 +5,12 @@ from tagger.interrogator.interrogator import AbsInterrogator
 from PIL import Image
 from pathlib import Path
 import argparse
+from PIL import ImageFile
 
 from tagger.interrogators import interrogators
+
+# Allow images with broken headers to load
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 parser = argparse.ArgumentParser()
 

--- a/run.py
+++ b/run.py
@@ -2,10 +2,9 @@ import sys
 
 from typing import Generator, Iterable
 from tagger.interrogator.interrogator import AbsInterrogator
-from PIL import Image
+from PIL import Image, ImageFile
 from pathlib import Path
 import argparse
-from PIL import ImageFile
 
 from tagger.interrogators import interrogators
 


### PR DESCRIPTION
https://github.com/corkborg/wd14-tagger-standalone/issues/28